### PR TITLE
github: upstream-sync: authenticate via SSH deploy key

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -29,10 +29,12 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          # NOTE: if branch protection is ever enabled on main or main-next
-          # (requiring PRs), replace GITHUB_TOKEN with secrets.SYNC_PAT here
-          # and in every git push step below.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use an SSH deploy key (with write access) so pushes that
+          # include upstream changes to .github/workflows/* are accepted.
+          # The default GITHUB_TOKEN is a GitHub App token and is hard-
+          # blocked from creating or updating workflow files; deploy keys
+          # are not subject to that restriction.
+          ssh-key: ${{ secrets.SYNC_SSH_KEY }}
 
       - name: Configure git identity
         run: |


### PR DESCRIPTION
The default GITHUB_TOKEN is a GitHub App token, which GitHub hard-blocks from creating or updating files under .github/workflows/, regardless of the contents: write permission. This caused the fast-forward push of fork/main to fail whenever upstream/main contained changes to its own workflow files.

Switch actions/checkout to authenticate via an SSH deploy key (secrets.SYNC_SSH_KEY) configured on the repository with write access. Deploy keys are not subject to the workflow-file restriction. Subsequent git fetch/push commands inherit the SSH remote URL configured by checkout, so no other steps require changes. The github-script steps that manage the sync-failure issue continue to use GITHUB_TOKEN, since deploy keys cannot perform API operations.

____

Instructions for the repo maintainer
____

Goal
                                                                                                                                                                                                                                                                                          
Allow the Upstream Sync workflow to push commits that include changes to .github/workflows/* (which the default GITHUB_TOKEN cannot do). We'll use an SSH deploy key with write access — repo-scoped, never expires, not tied to a personal account.

---                                                                                                                                                                                                                                                              
Step 1 — Generate the SSH key pair

On any local machine (Linux/macOS terminal):

ssh-keygen -t ed25519 -f upstream-sync-key -N "" -C "upstream-sync@FreedomVeiculosEletricos/zephyr"

This creates two files in the current directory:
- upstream-sync-key     (private key — keep secret)
- upstream-sync-key.pub (public key — goes into the repo)

Step 2 — Add the public key as a Deploy Key

1. Go to: https://github.com/FreedomVeiculosEletricos/zephyr/settings/keys
2. Click Add deploy key
3. Title: upstream-sync
4. Key: paste the entire contents of upstream-sync-key.pub
5. Check the box ☑️ Allow write access ← required
6. Click Add key

Step 3 — Add the private key as an Actions secret

1. Go to: https://github.com/FreedomVeiculosEletricos/zephyr/settings/secrets/actions
2. Click New repository secret
3. Name: SYNC_SSH_KEY (exactly this — case sensitive)
4. Secret: paste the entire contents of upstream-sync-key, including the -----BEGIN OPENSSH PRIVATE KEY----- and -----END OPENSSH PRIVATE KEY----- lines, with a trailing newline
5. Click Add secret

Step 4 — Destroy the local key files

Once both are uploaded:

shred -u upstream-sync-key upstream-sync-key.pub

(Or rm -P on macOS.) GitHub now has the only copies. If the key is ever compromised, delete the deploy key in step 2 and repeat the process — no other system holds it.

Step 5 — Merge PR

After keys be in place this PR can be merged.

---                                                                                                                                                                                                                                                                                     
Why this is safe to grant                                                                                                                                                                                                                                                               

- Scope: the key only has access to this single repo — it cannot read or write anywhere else on GitHub.
- No API access: deploy keys can only do git operations (clone/fetch/push). They cannot open issues, manage releases, or read other secrets.                                                                                                                                            
- Revocable: deleting the deploy key in Settings → Deploy keys instantly revokes all access.                                                                                                                                                                                            
- Audit trail: every push made with this key is logged and shows the configured git identity (github-actions[bot]).