### PR TITLE
ci: github: freedom: skip dynamic workflows in disable sweep

### DIFF
--- a/.github/workflows/freedom/disable-non-freedom-workflows.sh
+++ b/.github/workflows/freedom/disable-non-freedom-workflows.sh
@@ -7,6 +7,13 @@ set -euo pipefail
 gh api "repos/${REPO}/actions/workflows" --paginate \
   --jq '.workflows[] | [.id, .state, .path] | @tsv' |
 while IFS=$'\t' read -r id state path; do
+  # Only sweep real files under .github/workflows/. Skip
+  # GitHub-managed dynamic workflows (e.g. dependabot/update-graph,
+  # pages-build-deployment) — the disable API returns 422 for those.
+  case "$path" in
+    .github/workflows/*.yml|.github/workflows/*.yaml) ;;
+    *) continue ;;
+  esac
   base=$(basename "$path")
   shopt -s nocasematch
   if [[ "$base" =~ ^freedom[_-] ]]; then
@@ -18,5 +25,8 @@ while IFS=$'\t' read -r id state path; do
     continue
   fi
   echo "Disabling: $path (id=$id, was=$state)"
-  gh api -X PUT "repos/${REPO}/actions/workflows/${id}/disable"
+  if ! gh api -X PUT \
+       "repos/${REPO}/actions/workflows/${id}/disable"; then
+    echo "  warn: disable failed for id=$id ($path); continuing" >&2
+  fi
 done


### PR DESCRIPTION
GitHub returns auto-generated dynamic workflows (e.g. dynamic/dependabot/update-graph, pages-build-deployment) from the list-workflows API, but the disable endpoint rejects them with HTTP 422. Restrict the sweep to real files under .github/workflows/ so those entries are filtered out before any API call. Tolerate any remaining disable failure with a warning so a single rejected workflow does not abort the whole sync.